### PR TITLE
Add lxml to installed packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ install:
     # Install non-optional deps
     - "conda install -q --yes pytest Cython"
     # Install optional deps
-    - "conda install -q --yes scipy h5py beautiful-soup"
+    - "conda install -q --yes scipy h5py beautiful-soup lxml"
 
 # Not a .NET project, we build SunPy in the install step instead
 build: false


### PR DESCRIPTION
This should fix all of the tests in `astropy.io.ascii` that are failing on python 3.4.

Pinging @taldcroft and @amras1 because they were involved in the lxml-related issues that came up in astropy/astropy#2812 and astropy/astropy#2813 -- it may be that it would make sense to add lxml to the installed dependencies on the travis runs too (though the same tests that fail on windows/py34 pass on linux/py34).
