### PR TITLE
This adds a test decorator called @py3only

### DIFF
--- a/astropy/units/tests/py3_test_quantity_annotations.py
+++ b/astropy/units/tests/py3_test_quantity_annotations.py
@@ -1,9 +1,31 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-import astropy.units as u
+from functools import wraps
+from textwrap import dedent
 
+from ... import units as u
+from ...extern import six
+from ...tests.helper import pytest
+
+
+def py3only(func):
+    if not six.PY3:
+        return pytest.mark.skipif('not six.PY3')(func)
+    else:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            code = compile(dedent(func.__doc__), __file__, 'exec')
+            # This uses an unqualified exec statement illegally in Python 2,
+            # but perfectly allowed in Python 3 so in fact we eval the exec
+            # call :)
+            eval('exec(code)')
+
+        return wrapper
+
+
+@py3only
 def test_args3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary: u.arcsec):
         return solarx, solary
@@ -15,8 +37,12 @@ def test_args3():
 
     assert solarx.unit == u.arcsec
     assert solary.unit == u.arcsec
+    """
 
+
+@py3only
 def test_args_noconvert3():
+    """
     @u.quantity_input()
     def myfunc_args(solarx: u.arcsec, solary: u.arcsec):
         return solarx, solary
@@ -28,8 +54,12 @@ def test_args_noconvert3():
 
     assert solarx.unit == u.deg
     assert solary.unit == u.arcmin
+    """
 
+
+@py3only
 def test_args_nonquantity3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary):
         return solarx, solary
@@ -40,8 +70,12 @@ def test_args_nonquantity3():
     assert isinstance(solary, int)
 
     assert solarx.unit == u.arcsec
+    """
 
+
+@py3only
 def test_arg_equivalencies3():
+    """
     @u.quantity_input(equivalencies=u.mass_energy())
     def myfunc_args(solarx: u.arcsec, solary: u.eV):
         return solarx, solary
@@ -53,8 +87,12 @@ def test_arg_equivalencies3():
 
     assert solarx.unit == u.arcsec
     assert solary.unit == u.gram
+    """
 
+
+@py3only
 def test_wrong_unit3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary: u.deg):
         return solarx, solary
@@ -62,8 +100,12 @@ def test_wrong_unit3():
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to 'deg'."
+    """
 
+
+@py3only
 def test_not_quantity3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary: u.deg):
         return solarx, solary
@@ -71,8 +113,12 @@ def test_not_quantity3():
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be an astropy Quantity object"
+    """
 
+
+@py3only
 def test_decorator_override():
+    """
     @u.quantity_input(solarx=u.arcsec)
     def myfunc_args(solarx: u.km, solary: u.arcsec):
         return solarx, solary
@@ -84,8 +130,12 @@ def test_decorator_override():
 
     assert solarx.unit == u.arcsec
     assert solary.unit == u.arcsec
+    """
 
+
+@py3only
 def test_kwargs3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary, myk: u.arcsec=1*u.arcsec):
         return solarx, solary, myk
@@ -97,8 +147,12 @@ def test_kwargs3():
     assert isinstance(myk, u.Quantity)
 
     assert myk.unit == u.deg
+    """
 
+
+@py3only
 def test_unused_kwargs3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary, myk: u.arcsec=1*u.arcsec, myk2=1000):
         return solarx, solary, myk, myk2
@@ -112,8 +166,12 @@ def test_unused_kwargs3():
 
     assert myk.unit == u.deg
     assert myk2 == 10
+    """
 
+
+@py3only
 def test_kwarg_equivalencies3():
+    """
     @u.quantity_input(equivalencies=u.mass_energy())
     def myfunc_args(solarx: u.arcsec, energy: u.eV=10*u.eV):
         return solarx, energy
@@ -125,8 +183,12 @@ def test_kwarg_equivalencies3():
 
     assert solarx.unit == u.arcsec
     assert energy.unit == u.gram
+    """
 
+
+@py3only
 def test_kwarg_wrong_unit3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary: u.deg=10*u.deg):
         return solarx, solary
@@ -134,8 +196,12 @@ def test_kwarg_wrong_unit3():
     with pytest.raises(u.UnitsError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertable to 'deg'."
+    """
 
+
+@py3only
 def test_kwarg_not_quantity3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary: u.deg=10*u.deg):
         return solarx, solary
@@ -143,10 +209,15 @@ def test_kwarg_not_quantity3():
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100)
     assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be an astropy Quantity object"
+    """
 
+
+@py3only
 def test_kwarg_default3():
+    """
     @u.quantity_input
     def myfunc_args(solarx: u.arcsec, solary: u.deg=10*u.deg):
         return solarx, solary
 
     solarx, solary = myfunc_args(1*u.arcsec)
+    """

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
 from astropy.extern import six
 
-import astropy.units as u
+from ... import units as u
+from ...extern import six
+from ...tests.helper import pytest
 
-if not six.PY2:
-    from .py3_test_quantity_annotations import *
+
+from .py3_test_quantity_annotations import *
+
 
 def test_args():
     @u.quantity_input(solarx=u.arcsec, solary=u.arcsec)


### PR DESCRIPTION
Tests using this decorator should write the entire test in the test's docstring, so that it may contain Python 3 only syntax.  On Python 2 the test will be marked skip.  On Python 3 the test body will by compiled from the docstring and executed.  Perhaps some version of this could be moved to general test utilities, but for now this is the only test module we have, I think, that could make use of this.

I also fixed up some imports.
