### PR TITLE
Use MSVC when running tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,5 +56,5 @@ install:
 build: false
 
 test_script:
-  - "python setup.py test"
+  - "%CMD_IN_ENV% python setup.py test"
 


### PR DESCRIPTION
This should fix the compile error in appveyor, e.g. https://ci.appveyor.com/project/Astropy/astropy/build/1.0.26/job/as43458gtxrs49d6#L974
