### PR TITLE
Fix test failures for unit representation subclassing

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -42,8 +42,12 @@ class MetaBaseRepresentation(type):
         if cls.__name__ == 'BaseRepresentation':
             return
 
-        REPRESENTATION_CLASSES[cls.get_name()] = cls
+        repr_name = cls.get_name()
 
+        if repr_name in REPRESENTATION_CLASSES:
+            raise ValueError("Representation class {0} already defined".format(repr_name))
+
+        REPRESENTATION_CLASSES[repr_name] = cls
 
 def _fstyle(precision, x):
     fmt_str = '{0:.{precision}f}'

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -4,6 +4,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from copy import deepcopy
+
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -11,11 +13,21 @@ from ... import units as u
 from ...tests.helper import pytest
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
-from ..representation import (SphericalRepresentation,
+from ..representation import (REPRESENTATION_CLASSES,
+                              SphericalRepresentation,
                               UnitSphericalRepresentation,
                               CartesianRepresentation,
                               CylindricalRepresentation,
                               PhysicsSphericalRepresentation)
+
+
+def setup_function(func):
+    func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
+
+
+def teardown_function(func):
+    REPRESENTATION_CLASSES.clear()
+    REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
 
 
 def assert_allclose_quantity(q1, q2):

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -2,9 +2,12 @@
 This file tests the behaviour of subclasses of Representation and Frames
 """
 
+from copy import deepcopy
+
 from astropy.utils.compat.odict import OrderedDict
 from astropy.coordinates import Longitude, Latitude
-from astropy.coordinates.representation import (SphericalRepresentation,
+from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
+                                                SphericalRepresentation,
                                                 UnitSphericalRepresentation)
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
@@ -17,55 +20,68 @@ import astropy.coordinates
 
 # Classes setup, borrowed from SunPy.
 
-
-class Longitude180(Longitude):
-    def __new__(cls, angle, unit=None, wrap_angle=180*u.deg, **kwargs):
-        self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
-                                                wrap_angle=wrap_angle, **kwargs)
-        return self
+# Here we define the classes *inside* the tests to make sure that we can wipe
+# the slate clean when the tests have finished running.
 
 
-class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
-    attr_classes = OrderedDict([('lon', Longitude180),
-                                ('lat', Latitude)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
+def setup_function(func):
+    func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
 
 
-class SphericalWrap180Representation(SphericalRepresentation):
-    attr_classes = OrderedDict([('lon', Longitude180),
-                                ('lat', Latitude),
-                                ('distance', u.Quantity)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
-
-    _unit_representation = UnitSphericalWrap180Representation
+def teardown_function(func):
+    REPRESENTATION_CLASSES.clear()
+    REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
 
 
-class myframe(ICRS):
-    default_representation = SphericalWrap180Representation
-    frame_specific_representation_info = {
-        'spherical': [RepresentationMapping('lon', 'ra'),
-                      RepresentationMapping('lat', 'dec')]
-    }
-    frame_specific_representation_info['unitspherical'] = \
-    frame_specific_representation_info['unitsphericalwrap180'] = \
-    frame_specific_representation_info['sphericalwrap180'] = \
-        frame_specific_representation_info['spherical']
+def test_unit_representation_subclass():
+
+    class Longitude180(Longitude):
+        def __new__(cls, angle, unit=None, wrap_angle=180*u.deg, **kwargs):
+            self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
+                                                    wrap_angle=wrap_angle, **kwargs)
+            return self
 
 
-@frame_transform_graph.transform(FunctionTransform,
-                                 myframe, astropy.coordinates.ICRS)
-def myframe_to_icrs(myframe_coo, icrs):
-    return icrs.realize_frame(myframe_coo._data)
+    class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude)])
+        recommended_units = {'lon': u.deg, 'lat': u.deg}
 
 
-def test_init():
+    class SphericalWrap180Representation(SphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude),
+                                    ('distance', u.Quantity)])
+        recommended_units = {'lon': u.deg, 'lat': u.deg}
+
+        _unit_representation = UnitSphericalWrap180Representation
+
+
+    class myframe(ICRS):
+        default_representation = SphericalWrap180Representation
+        frame_specific_representation_info = {
+            'spherical': [RepresentationMapping('lon', 'ra'),
+                          RepresentationMapping('lat', 'dec')]
+        }
+        frame_specific_representation_info['unitspherical'] = \
+        frame_specific_representation_info['unitsphericalwrap180'] = \
+        frame_specific_representation_info['sphericalwrap180'] = \
+            frame_specific_representation_info['spherical']
+
+
+    @frame_transform_graph.transform(FunctionTransform,
+                                     myframe, astropy.coordinates.ICRS)
+    def myframe_to_icrs(myframe_coo, icrs):
+        return icrs.realize_frame(myframe_coo._data)
+
     f = myframe(10*u.deg, 10*u.deg)
     assert isinstance(f._data, UnitSphericalWrap180Representation)
-    assert isinstance(f.lon, Longitude180)
+    assert isinstance(f.ra, Longitude180)
 
-
-def test_transform():
-    f = myframe(10*u.deg, 10*u.deg)
     g = f.transform_to(astropy.coordinates.ICRS)
     assert isinstance(g, astropy.coordinates.ICRS)
     assert isinstance(g._data, UnitSphericalWrap180Representation)
+
+    frame_transform_graph.remove_transform(myframe,
+                                           astropy.coordinates.ICRS,
+                                           None)


### PR DESCRIPTION
Make sure that tests don’t permanently modify the dictionary of representation
classes, and that custom transform is removed from transform graph after tests