### PR TITLE
Cm units

### DIFF
--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -174,7 +174,7 @@ class BlackBody1D(Fittable1DModel):
 
     # We allow values without units to be passed when evaluating the model, and
     # in this case the input x values are assumed to be frequencies in Hz.
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     # We enable the spectral equivalency by default for the spectral axis
     input_units_equivalencies = {'x': u.spectral()}

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -124,6 +124,13 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         cls._create_inverse_property(members)
         cls._create_bounding_box_property(members)
         cls._handle_special_methods(members)
+        #if 'inputs' in members and isinstance(cls.input_units_strict, bool):
+            #inp = members['inputs']
+            #if isinstance(inp, tuple) and inp:
+                #print('members,', name, inp, cls.input_units_strict)
+                #cls.input_units_strict = {key: cls.input_units_strict for key in inp}
+
+
 
     def __repr__(cls):
         """
@@ -656,7 +663,7 @@ class Model(metaclass=_ModelMeta):
     # input_units. In this case, if the input quantities are convertible to
     # input_units, they are converted. If this is a dictionary then it should
     # map input name to a bool to set strict input units for that parameter.
-    input_units_strict = False
+    input_units_strict = False #{key: False for key in inputs}
 
     # Allow dimensionless input (and corresponding output). If this is True,
     # input values to evaluate will gain the units specified in input_units. If
@@ -681,6 +688,10 @@ class Model(metaclass=_ModelMeta):
         # Parameter values must be passed in as keyword arguments in order to
         # distinguish them
         self._initialize_parameters(args, kwargs)
+        ius = self.input_units_strict
+        #if not ius:
+        if isinstance(ius, bool):
+            self.input_units_strict = {key: ius for key in self.__class__.inputs}
 
     def __repr__(self):
         return self._format_repr()
@@ -1487,15 +1498,15 @@ class Model(metaclass=_ModelMeta):
                         # to be able to raise more appropriate/nicer exceptions
 
                         if input_unit is dimensionless_unscaled:
-                            raise UnitsError("Units of input '{0}', {1} ({2}), could not be "
+                            raise UnitsError("{0}: Units of input '{1}', {2} ({3}), could not be "
                                              "converted to required dimensionless "
                                              "input".format(self.inputs[i],
                                                             inputs[i].unit,
                                                             inputs[i].unit.physical_type))
                         else:
-                            raise UnitsError("Units of input '{0}', {1} ({2}), could not be "
+                            raise UnitsError("{0}: Units of input '{1}', {2} ({3}), could not be "
                                              "converted to required input units of "
-                                             "{3} ({4})".format(self.inputs[i],
+                                             "{4} ({5})".format(self.name, self.inputs[i],
                                                                 inputs[i].unit,
                                                                 inputs[i].unit.physical_type,
                                                                 input_unit,

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -651,8 +651,8 @@ class Model(metaclass=_ModelMeta):
     # model hasn't completed initialization yet
     _n_models = 1
 
-    # New classes can set thi sas a boolean value.
-    # It is turned into a dictionary mapping input name to a boolean.
+    # New classes can set this as a boolean value.
+    # It is converted to a dictionary mapping input name to a boolean value.
     _input_units_strict = False
 
     # Allow dimensionless input (and corresponding output). If this is True,

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -461,9 +461,9 @@ class Shift(Fittable1DModel):
     offset = Parameter(default=0)
     linear = True
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):
@@ -482,14 +482,7 @@ class Shift(Fittable1DModel):
     @staticmethod
     def evaluate(x, offset):
         """One dimensional Shift model function"""
-        if isinstance(offset, u.Quantity):
-            return_unit = offset.unit
-            offset = offset.value
-        if isinstance(x, u.Quantity):
-            x = x.value
-            return (x + offset) * return_unit
-        else:
-            return x + offset
+        return x + offset
 
     @staticmethod
     def sum_of_implicit_terms(x):
@@ -521,9 +514,9 @@ class Scale(Fittable1DModel):
     linear = True
     fittable = True
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -55,7 +55,9 @@ class Mapping(FittableModel):
                                  for idx in range(n_inputs))
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
+        self.input_units_strict = {key: False for key in self._inputs}
         super().__init__(name=name, meta=meta)
+
 
     @property
     def inputs(self):

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -56,6 +56,7 @@ class Mapping(FittableModel):
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
         self.input_units_strict = {key: False for key in self._inputs}
+        self.input_units_allow_dimensionless = {key: False for key in self._inputs}
         super().__init__(name=name, meta=meta)
 
 

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -120,8 +120,8 @@ class Pix2SkyProjection(Projection):
     inputs = ('x', 'y')
     outputs = ('phi', 'theta')
 
-    input_units_strict = True
-    input_units_allow_dimensionless = True
+    _input_units_strict = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):
@@ -138,8 +138,8 @@ class Sky2PixProjection(Projection):
     inputs = ('phi', 'theta')
     outputs = ('x', 'y')
 
-    input_units_strict = True
-    input_units_allow_dimensionless = True
+    _input_units_strict = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -95,9 +95,9 @@ class _EulerRotation:
             b.shape = shape
         return a, b
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):
@@ -345,9 +345,9 @@ class Rotation2D(Model):
 
     angle = Parameter(default=0.0, getter=_to_orig_unit, setter=_to_radian)
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def inverse(self):

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -42,7 +42,7 @@ def test_evaluate_with_quantities():
     # error is raised
     with pytest.raises(UnitsError) as exc:
         gq(1)
-    assert exc.value.args[0] == ("Units of input 'x', (dimensionless), could not be "
+    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', (dimensionless), could not be "
                                  "converted to required input units of m (length)")
 
     # However, zero is a special case
@@ -54,7 +54,7 @@ def test_evaluate_with_quantities():
     # But not with incompatible units
     with pytest.raises(UnitsError) as exc:
         gq(3 * u.s)
-    assert exc.value.args[0] == ("Units of input 'x', s (time), could not be "
+    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', s (time), could not be "
                                  "converted to required input units of m (length)")
 
     # We also can't evaluate the model without quantities with a quantity
@@ -75,7 +75,7 @@ def test_evaluate_with_quantities_and_equivalencies():
     # We aren't setting the equivalencies, so this won't work
     with pytest.raises(UnitsError) as exc:
         g(30 * u.PHz)
-    assert exc.value.args[0] == ("Units of input 'x', PHz (frequency), could "
+    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', PHz (frequency), could "
                                  "not be converted to required input units of "
                                  "nm (length)")
 
@@ -115,12 +115,12 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("Units of input 'a', s (time), could not be "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', s (time), could not be "
                                      "converted to required input units of deg (angle)")
 
         with pytest.raises(UnitsError) as exc:
             self.model(3, 3)
-        assert exc.value.args[0] == ("Units of input 'a', (dimensionless), could "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', (dimensionless), could "
                                      "not be converted to required input units of deg (angle)")
 
     def test_input_units_allow_dimensionless(self):
@@ -133,7 +133,7 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("Units of input 'a', s (time), could not be "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', s (time), could not be "
                                      "converted to required input units of deg (angle)")
 
         assert_quantity_allclose(self.model(3, 3), 9)
@@ -155,7 +155,7 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(3 * u.PHz, 3)
-        assert exc.value.args[0] == ("Units of input 'a', PHz (frequency), could "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', PHz (frequency), could "
                                      "not be converted to required input units of "
                                      "micron (length)")
 
@@ -308,13 +308,13 @@ def test_compound_input_units_equivalencies():
     assert_quantity_allclose(out, 20 * u.deg)
 
     cs = s1 & s2
-
+    cs = cs.rename('TestModel')
     out = cs(20 * u.pix, 10 * u.deg)
     assert_quantity_allclose(out, 20 * u.deg)
 
     with pytest.raises(UnitsError) as exc:
         out = cs(20 * u.pix, 10 * u.pix)
-    assert exc.value.args[0] == "Units of input 'x1', pix (unknown), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "TestModel: Units of input 'x1', pix (unknown), could not be converted to required input units of deg (angle)"
 
 
 def test_compound_input_units_strict():
@@ -361,7 +361,7 @@ def test_compound_input_units_allow_dimensionless():
     s2 = Scale(2)
 
     cs = s1 | s2
-
+    cs = cs.rename('TestModel')
     out = cs(10)
     assert_quantity_allclose(out, 40 * u.one)
 
@@ -370,19 +370,21 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10 * u.m)
-    assert exc.value.args[0] == "Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "TestModel: Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
 
     s1.input_units_allow_dimensionless = False
 
     cs = s1 | s2
+    cs = cs.rename('TestModel')
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10)
-    assert exc.value.args[0] == "Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "TestModel: Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
 
     s1.input_units_allow_dimensionless = True
 
     cs = s2 | s1
+    cs = cs.rename('TestModel')
 
     out = cs(10)
     assert_quantity_allclose(out, 40 * u.one)
@@ -392,7 +394,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10 * u.m)
-    assert exc.value.args[0] == "Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "ScaleDegrees: Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
 
     s1.input_units_allow_dimensionless = False
 
@@ -400,7 +402,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10)
-    assert exc.value.args[0] == "Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "ScaleDegrees: Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
 
     s1.input_units_allow_dimensionless = True
 
@@ -410,6 +412,7 @@ def test_compound_input_units_allow_dimensionless():
     s2.input_units_allow_dimensionless = False
 
     cs = s1 & s2
+    cs = cs.rename('TestModel')
 
     out = cs(10, 10 * u.arcsec)
     assert_quantity_allclose(out[0], 20 * u.one)
@@ -417,7 +420,7 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10, 10)
-    assert exc.value.args[0] == "Units of input 'x1', (dimensionless), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "TestModel: Units of input 'x1', (dimensionless), could not be converted to required input units of deg (angle)"
 
 
 def test_compound_return_units():


### PR DESCRIPTION
@Cadair @astrofrog I think this addresses everything I mentioned.

The name is set to the class name in case model.name is None.
`input_units_allow_dimensionless` and `input_units_strict` are now turned into dictionaries in the initialization step. I had to make them properties to support the case of setting them as bool after the model is created, e.g. `m = MyModel(); m.input_units_strict=True`.

Please review and see if you agree with these changes.