### PR TITLE
Use numpy's memmap and avoid changing ostream's file mode

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -54,7 +54,7 @@ explanation of all the different formats.
     around a single format and officially deprecate the other formats.
 """
 
-
+import pathlib
 import operator
 import os
 import warnings
@@ -72,6 +72,11 @@ from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
 
+try:
+    from dask.array import Array as DaskArray
+except ImportError:
+    class DaskArray:
+        pass
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
            'append', 'update', 'info', 'tabledump', 'tableload',
@@ -1061,7 +1066,7 @@ def _makehdu(data, header):
         if ((isinstance(data, np.ndarray) and data.dtype.fields is not None) or
                 isinstance(data, np.recarray)):
             hdu = BinTableHDU(data, header=header)
-        elif isinstance(data, np.ndarray):
+        elif isinstance(data, (np.ndarray, DaskArray)):
             hdu = ImageHDU(data, header=header)
         else:
             raise KeyError('Data must be a numpy array.')
@@ -1069,6 +1074,8 @@ def _makehdu(data, header):
 
 
 def _stat_filename_or_fileobj(filename):
+    if isinstance(filename, pathlib.Path):
+        filename = str(filename)
     closed = fileobj_closed(filename)
     name = fileobj_name(filename) or ''
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -43,7 +43,7 @@ IO_FITS_MODES = {
     'copyonwrite': 'rb',
     'update': 'rb+',
     'append': 'ab+',
-    'ostream': 'wb+',
+    'ostream': 'wb',
     'denywrite': 'rb'}
 
 # Maps OS-level file modes to the appropriate astropy.io.fits specific mode

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -689,18 +689,15 @@ class _ImageBaseHDU(_ValidHDU):
         fileobj.write(b'\0')
         fileobj.flush()
 
-        outmmap = mmap.mmap(fileobj._file.fileno(),
-                            length=initial_position + n_bytes,
-                            access=mmap.ACCESS_WRITE)
-
-        outarr = np.ndarray(shape=output.shape,
-                            dtype=output.dtype,
-                            offset=initial_position,
-                            buffer=outmmap)
+        outarr = np.memmap(fileobj.name,
+                           mode='r+',
+                           shape=output.shape,
+                           dtype=output.dtype,
+                           offset=initial_position)
 
         output.store(outarr, lock=True, compute=True)
 
-        outmmap.close()
+        outarr._mmap.close()
 
         # On Windows closing the memmap causes the file pointer to return to 0, so
         # we need to go back to the end of the data (since padding may be written

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -139,3 +139,19 @@ def test_scaled_minmax(dask_array_in_mem, tmp_path):
     with fits.open(filename) as hdulist_new:
         assert isinstance(hdulist_new[0].data, np.ndarray)
         np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute(), atol=1e-5)
+
+
+def test_append(dask_array_in_mem, tmp_path):
+
+    # Test append mode
+
+    filename = tmp_path / 'test.fits'
+
+    fits.append(filename, dask_array_in_mem)
+    fits.append(filename, np.arange(10))
+
+    with fits.open(filename) as hdulist_new:
+        assert isinstance(hdulist_new[0].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
+        assert isinstance(hdulist_new[1].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[1].data, np.arange(10))


### PR DESCRIPTION
@Cadair @astrofrog : proposal to avoid changing ostream mode by creating the memmap from the file name instead of reusing the file descriptor. Also I use numpy, but could do the same directly with mmap.